### PR TITLE
SRV-1015 move cert and ca to methods 

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'operations@onetwotrip.com'
 license          'LGPLv3'
 description      'Installs/Configures cfssl'
 long_description 'Installs/Configures cfssl'
-version          '0.2.2'
+version          '0.2.3'
 
 issues_url       'https://github.com/onetwotrip/chef-cfssl/issues'
 source_url       'https://github.com/onetwotrip/chef-cfssl'


### PR DESCRIPTION
Move cert and ca to methods  to make them accessible from the outside (in recipe)

``` Ruby
cfssl = cfssl_gencert 'default' do
  action :create
end

Chef::Log.info("CERT #{cfssl.cert}")
Chef::Log.info("CA #{cfssl.ca}")
```

Also chomp them to leave out newline management
